### PR TITLE
Change to only collect latest CommandExecution.log

### DIFF
--- a/pyServer/manifests/windows/agents
+++ b/pyServer/manifests/windows/agents
@@ -38,7 +38,7 @@ copy,/WindowsAzure/config/*.xml
 copy,/WindowsAzure/Logs/AggregateStatus/aggregatestatus*.json
 copy,/WindowsAzure/Logs/AppAgentRuntime.log
 copy,/WindowsAzure/Logs/MonitoringAgent.log
-copy,/WindowsAzure/Logs/Plugins/*/*/CommandExecution*.log
+copy,/WindowsAzure/Logs/Plugins/*/*/CommandExecution.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Install.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Update.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Heartbeat.log

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -94,7 +94,7 @@ copy,/WindowsAzure/config/*.xml
 copy,/WindowsAzure/Logs/AggregateStatus/aggregatestatus*.json
 copy,/WindowsAzure/Logs/AppAgentRuntime.log
 copy,/WindowsAzure/Logs/MonitoringAgent.log
-copy,/WindowsAzure/Logs/Plugins/*/*/CommandExecution*.log
+copy,/WindowsAzure/Logs/Plugins/*/*/CommandExecution.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Install.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Update.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Heartbeat.log

--- a/pyServer/manifests/windows/normal
+++ b/pyServer/manifests/windows/normal
@@ -48,7 +48,7 @@ copy,/WindowsAzure/config/*.xml
 copy,/WindowsAzure/Logs/AggregateStatus/aggregatestatus*.json
 copy,/WindowsAzure/Logs/AppAgentRuntime.log
 copy,/WindowsAzure/Logs/MonitoringAgent.log
-copy,/WindowsAzure/Logs/Plugins/*/*/CommandExecution*.log
+copy,/WindowsAzure/Logs/Plugins/*/*/CommandExecution.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Install.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Update.log
 copy,/WindowsAzure/Logs/Plugins/*/*/Heartbeat.log


### PR DESCRIPTION
Change to normal, diagnostic, and agents manifests to only collect the latest CommandExecution.log as getting CommandExecution*.log was pulling back a large number of them when the latest is usually the one you are interested in.