### PR TITLE
Adding timestamps for result.txt file operations, basic FreeBSD support, and disk information

### DIFF
--- a/pyServer/GuestFS.py
+++ b/pyServer/GuestFS.py
@@ -162,6 +162,16 @@ class GuestFS:
         except subprocess.CalledProcessError:
             return False
         return True
+        
+    #used to mount ufs filesystems on FreeBSD VMs    
+    def mount_bsd(self, mountpoint, device):
+        try:
+            (out, err) = self.callGF('Mount [' + mountpoint + ',' + device + ']', ['--', '-mount-options', 'ro,ufstype=5xbsd', device, mountpoint], True)
+            if err:
+                return False
+        except subprocess.CalledProcessError:
+            return False
+        return True
 
     def ll(self, directory):
         try:

--- a/pyServer/GuestFS.py
+++ b/pyServer/GuestFS.py
@@ -211,3 +211,31 @@ class GuestFS:
 
     def exit(self):
         return self.callGF('Exiting', ['--', '-exit'])
+
+    
+    def df(self):
+        try:
+            (out, err) = self.callGF('DiskInfo (df -h)', ['--', '-df-h'], True)
+            if err:
+                return None
+        except subprocess.CalledProcessError:
+            return None
+        return out
+
+    def statvfs(self, mountpoint):
+        try:
+            (out, err) = self.callGF('DiskInfo (statvfs)', ['--', '-statvfs', mountpoint], True)
+            if err:
+                return None
+        except subprocess.CalledProcessError:
+            return None
+        return out 
+        
+    def get_drive_letters(self, device):
+        try:
+            (out, err) = self.callGF('Windows drive letter mappings', ['--', '-inspect-get-drive-mappings', device], True)
+            if err:
+                return None
+        except subprocess.CalledProcessError:
+            return None
+        return out

--- a/pyServer/GuestFishWrapper.py
+++ b/pyServer/GuestFishWrapper.py
@@ -279,7 +279,31 @@ class GuestFishWrapper:
                                             duration_seconds = (step_end_time - operation_start_time).seconds
                                             strMsg = step_end_time.strftime('%H:%M:%S') + "  Copying Step [" + strStepDescription + "] File: " + actualFileName + step_result + "  [Operation duration: " + str(duration_seconds) + " seconds]"
                                             self.WriteToResultFile(operationOutFile, strMsg)
+                                elif opCommand=="diskinfo":  
+                                    diskInfoOutFilename = requestDir + os.sep + 'diskinfo.txt'  
+                                    with open(diskInfoOutFilename, "a", newline="\r\n") as diskInfoOutFile:                                    
+                                        # get drive letters if we ran inspection
+                                        if (osType == "windows"):
+                                            if (not skipInspect):  
+                                                driveMappings = guestfish.get_drive_letters(device)
+                                                self.WriteToResultFileWithHeader(diskInfoOutFile, "Windows drive letter mappings:", driveMappings)
+                                            else:
+                                                self.WriteToResultFileWithHeader(diskInfoOutFile, "Windows drive letter mappings [Inspect skipped]:", "C: " + device)
+                                        #df-h
+                                        diskInfo = guestfish.df()
+                                        self.WriteToResultFile(diskInfoOutFile, diskInfo)
+                                        #statvfs                                       
+                                        self.WriteToResultFile(diskInfoOutFile, "\r\nFor decoder ring for data below see: http://man.he.net/man2/statvfs \r\n")
+                                        for mount in osMountpoints:
+                                            mountpoint = mount[0]
+                                            mountdevice = mount[1]
+                                            diskstats=guestfish.statvfs(mountpoint)
+                                            self.WriteToResultFileWithHeader(diskInfoOutFile, "[Device: " + mountdevice + ", mountpoint: " + mountpoint + " ]", diskstats)
                                             
+                                    step_end_time = datetime.now() 
+                                    duration_seconds = (step_end_time - operation_start_time).seconds                                    
+                                    strMsg = step_end_time.strftime('%H:%M:%S') + "  DiskInfo gathered. [Operation duration: " + str(duration_seconds) + " seconds]"
+                                    self.WriteToResultFile(operationOutFile, strMsg)
                     finally:
                         # Unmount all mountpoints
                         guestfish.unmount_all()

--- a/pyServer/manifests/freebsd/agents
+++ b/pyServer/manifests/freebsd/agents
@@ -1,0 +1,17 @@
+echo,### Probing Directories ###
+ll,/var/log
+ll,/var/lib/waagent
+
+echo,### Gathering Configuration Files ###
+copy,/etc/*-release
+copy,/etc/hostname
+copy,/etc/dhclient.conf
+copy,/etc/waagent.conf
+copy,/var/lib/waagent/*.xml
+echo,
+
+echo,### Gathering Log Files ###
+copy,/var/log/waagent*
+copy,/var/log/dmesg*
+copy,/var/log/auth*
+copy,/var/log/azure/*/*/*

--- a/pyServer/manifests/freebsd/diagnostic
+++ b/pyServer/manifests/freebsd/diagnostic
@@ -1,0 +1,23 @@
+echo,### Probing Directories ###
+ll,/var/log
+ll,/etc/rc.d
+
+echo,### Gathering Configuration Files ###
+copy,/etc/fstab
+copy,/etc/ssh/sshd_config
+copy,/boot/loader.conf
+copy,/etc/dhclient.conf
+copy,/etc/networks
+copy,/etc/nsswitch.conf
+copy,/etc/resolv.conf
+copy,/etc/rc.conf
+copy,/etc/syslog.conf
+copy,/etc/waagent.conf
+echo,
+
+echo,### Gathering Log Files ###
+copy,/var/log/waagent*
+copy,/var/log/messages*
+copy,/var/log/dmesg*
+copy,/var/log/auth*
+copy,/var/log/secure*

--- a/pyServer/manifests/freebsd/normal
+++ b/pyServer/manifests/freebsd/normal
@@ -1,0 +1,16 @@
+echo,### Probing Directories ###
+ll,/var/log
+ll,/etc/rc.d
+
+echo,### Gathering Configuration Files ###
+copy,/etc/fstab
+copy,/etc/ssh/sshd_config
+echo,
+
+echo,### Gathering Log Files ###
+copy,/var/log/waagent*
+copy,/var/log/messages*
+copy,/var/log/dmesg*
+copy,/var/log/boot*
+copy,/var/log/auth*
+copy,/boot/loader.conf

--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -39,3 +39,6 @@ copy,/var/log/cloud-init*
 copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*
+
+echo,### Gathering Disk Info ###
+diskinfo,

--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -174,3 +174,6 @@ copy,/Packages/Plugins/Microsoft.Powershell.DSC/*/DSCVersion.xml
 copy,/Packages/Plugins/Microsoft.Powershell.DSC/*/DSCWork/HotfixInstallInProgress.dsc
 copy,/Packages/Plugins/Microsoft.Powershell.DSC/*/DSCWork/PreInstallDone.dsc
 copy,/Packages/Plugins/Microsoft.SqlServer.Management.SqlIaaSAgent/*/PackageDefinition.xml
+
+echo,### Gathering Disk Info ###
+diskinfo,


### PR DESCRIPTION
Adding timestamps for result.txt file operations to improve understanding the causes of timeouts (e.g. too much aggregate time, a problematic file, etc).

Adding basic support for FreeBSD; including normal, agent, and diagnostics manifests.

Attached is a sample [results.txt](https://github.com/amitchat/azure-diskinspect-service/files/595762/results.txt)

