### PR TITLE
Add copy,/var/log/azure/*/*/* to manifest

### DIFF
--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -39,6 +39,7 @@ copy,/var/log/cloud-init*
 copy,/var/log/boot*
 copy,/var/log/auth*
 copy,/var/log/secure*
+copy,/var/log/azure/*/*/*
 
 echo,### Gathering Disk Info ###
 diskinfo,


### PR DESCRIPTION
Add copy,/var/log/azure/*/*/* to diagnostic manifest as it is commonly needed, so we want it in not just the agents manifest, but also the normal and diagnostic manifest. This will bring parity with the behavior of the Windows manifests, where normal, diagnostic, and agents manifests all collect guest agent logs.