### PR TITLE
Add copy,/var/log/azure/*/*/* to manifest

### DIFF
--- a/pyServer/manifests/freebsd/diagnostic
+++ b/pyServer/manifests/freebsd/diagnostic
@@ -21,3 +21,4 @@ copy,/var/log/messages*
 copy,/var/log/dmesg*
 copy,/var/log/auth*
 copy,/var/log/secure*
+copy,/var/log/azure/*/*/*


### PR DESCRIPTION
Add copy,/var/log/azure/*/*/* to normal manifest as it is commonly needed, so we want it in not just the agents manifest, but also the normal and diagnostic manifest. This will bring parity with the behavior of the Windows manifests, where normal, diagnostic, and agents manifests all collect guest agent logs.