### PR TITLE
Update rdp-registry to include CleanupProfiles value

### DIFF
--- a/pyServer/manifests/windows/rdp-registry
+++ b/pyServer/manifests/windows/rdp-registry
@@ -27,3 +27,4 @@ reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\RemoteDesktop
 reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-In-TCP
 reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-In-TCP-PUBLIC
 reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-Compat-In-TCP
+reg,HKLM\SOFTWARE\Policies\Microsoft\Windows\System\CleanupProfiles


### PR DESCRIPTION
The CleanupProfiles reg value is set when the "Delete user profiles older than a specified number of days on system restart" group policy is set. This policy is known to cause a deadlock that ultimately prevents RDP connectivity, so having this manifest collect it will show us if it has been enabled. It is not enabled by default.