### PR TITLE
Updated to include MSConfig reg key

### DIFF
--- a/pyServer/manifests/windows/rdp-registry
+++ b/pyServer/manifests/windows/rdp-registry
@@ -28,3 +28,4 @@ reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-In
 reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-In-TCP-PUBLIC
 reg,HKLM\SOFTWARE\Policies\Microsoft\WindowsFirewall\FirewallRules\WINRM-HTTP-Compat-In-TCP
 reg,HKLM\SOFTWARE\Policies\Microsoft\Windows\System\CleanupProfiles
+reg,HKLM\SOFTWARE\Microsoft\Shared Tools\MSConfig


### PR DESCRIPTION
Updated to include MSConfig reg key, allowing us to check if they disabled any services using MSConfig which may be contributing to Can't RDP.