### PR TITLE
FixStateIniFileNameCaseDiagnosticsWindowsManifest

### DIFF
--- a/pyServer/manifests/windows/diagnostic
+++ b/pyServer/manifests/windows/diagnostic
@@ -58,7 +58,7 @@ copy,/Windows/System32/winevt/Logs/Microsoft-Windows-DSC%4Operational.evtx
 
 echo,### Provisioning ###
 copy,/AzureData/CustomData.bin
-copy,/Windows/Setup/State/state.ini
+copy,/Windows/Setup/State/State.ini
 copy,/Windows/Panther/WaSetup.xml
 copy,/Windows/Panther/WaSetup.log
 copy,/Windows/Panther/unattend.xml


### PR DESCRIPTION
Fix filename case for State.ini in Windows Diagnostics Manifest