### PR TITLE
RHEL 6's DHCP Lease (#44)

### DIFF
--- a/pyServer/manifests/linux/diagnostic
+++ b/pyServer/manifests/linux/diagnostic
@@ -25,6 +25,7 @@ copy,/etc/sysconfig/SuSEfirewall2
 copy,/etc/ufw/ufw.conf
 copy,/etc/waagent.conf
 copy,/var/lib/dhcp/dhclient.eth0.leases
+copy,/var/lib/dhclient/dhclient-eth0.leases
 echo,
 
 echo,### Gathering Log Files ###


### PR DESCRIPTION
RHEL 6 (and flavors) keeps the DHCP lease file in a different location.